### PR TITLE
Make InputStreamDecrypter.read() InputStream compliant

### DIFF
--- a/src/main/java/com/google/crypto/tink/streamingaead/InputStreamDecrypter.java
+++ b/src/main/java/com/google/crypto/tink/streamingaead/InputStreamDecrypter.java
@@ -121,7 +121,7 @@ final class InputStreamDecrypter extends InputStream {
   public synchronized int read() throws IOException {
     byte[] oneByte = new byte[1];
     if (read(oneByte) == 1) {
-      return oneByte[0];
+      return oneByte[0] & 0xff;
     }
     return -1;
   }


### PR DESCRIPTION
Convert the read signed integer to unsigned before returning it, because it is the behavior defined in the InputStream interface. It also makes it possible to distinguish between errors and successful read operations.

Fixes #10.