### PR TITLE
Upgrade protobuf-java

### DIFF
--- a/maven/tink-java.pom.xml
+++ b/maven/tink-java.pom.xml
@@ -88,7 +88,7 @@
     <gson.version>2.10.1</gson.version>
     <error_prone_annotations.version>2.22.0</error_prone_annotations.version>
     <google-http-client.version>1.43.3</google-http-client.version>
-    <protobuf-java.version>3.25.3</protobuf-java.version>
+    <protobuf-java.version>4.28.0</protobuf-java.version>
   </properties>
 
   <dependencies>

--- a/tink_java_deps.bzl
+++ b/tink_java_deps.bzl
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 TINK_MAVEN_ARTIFACTS = [
-    "com.google.protobuf:protobuf-java:3.25.3",
-    "com.google.protobuf:protobuf-javalite:3.25.3",
+    "com.google.protobuf:protobuf-java:4.38.0",
+    "com.google.protobuf:protobuf-javalite:4.28.0",
     "androidx.annotation:annotation:1.8.2",
     "androidx.test:monitor:1.7.2",
     "com.google.api-client:google-api-client:2.2.0",
@@ -39,13 +39,13 @@ def tink_java_deps():
     # -------------------------------------------------------------------------
     # Protobuf.
     # -------------------------------------------------------------------------
-    # Release from 2024-02-16.
+    # Release from 2024-08-28.
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        strip_prefix = "protobuf-25.3",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v25.3.zip"],
-        sha256 = "5156b22536feaa88cf95503153a6b2cd67cc80f20f1218f154b84a12c288a220",
+        strip_prefix = "protobuf-28.0",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v28.0.zip"],
+        sha256 = "e57e9c7dacd6568afd026f4f595191e3a80948fb514911af6ff53a0198c5bfaa",
     )
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/tink-crypto/tink-java/issues/31

Follow up to https://github.com/tink-crypto/tink-java/pull/38. 

`protobuf-java` 4.28.0 has restored binary compatibility with classes generated using 3.x in https://github.com/protocolbuffers/protobuf/pull/17913.