### PR TITLE
Upgrade protobuf to 4.28.2

### DIFF
--- a/maven/tink-java.pom.xml
+++ b/maven/tink-java.pom.xml
@@ -88,7 +88,7 @@
     <gson.version>2.10.1</gson.version>
     <error_prone_annotations.version>2.22.0</error_prone_annotations.version>
     <google-http-client.version>1.43.3</google-http-client.version>
-    <protobuf-java.version>4.28.0</protobuf-java.version>
+    <protobuf-java.version>4.28.2</protobuf-java.version>
   </properties>
 
   <dependencies>

--- a/tink_java_deps.bzl
+++ b/tink_java_deps.bzl
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 TINK_MAVEN_ARTIFACTS = [
-    "com.google.protobuf:protobuf-java:4.28.0",
-    "com.google.protobuf:protobuf-javalite:4.28.0",
+    "com.google.protobuf:protobuf-java:4.28.2",
+    "com.google.protobuf:protobuf-javalite:4.28.2",
     "androidx.annotation:annotation:1.8.2",
     "androidx.test:monitor:1.7.2",
     "com.google.api-client:google-api-client:2.2.0",
@@ -39,13 +39,13 @@ def tink_java_deps():
     # -------------------------------------------------------------------------
     # Protobuf.
     # -------------------------------------------------------------------------
-    # Release from 2024-08-28.
+    # Release from 2024-09-18.
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        strip_prefix = "protobuf-28.0",
-        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v28.0/protobuf-28.0.tar.gz"],
-        sha256 = "13e7749c30bc24af6ee93e092422f9dc08491c7097efa69461f88eb5f61805ce",
+        strip_prefix = "protobuf-28.2",
+        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protobuf-28.2.tar.gz"],
+        sha256 = "b2340aa47faf7ef10a0328190319d3f3bee1b24f426d4ce8f4253b6f27ce16db",
     )
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
The version currently in use (4.28.0) is vulnerable to [CVE-2024-7254](https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-735f-pc8j-v9w8).