### PR TITLE
Fix RSA-KEM decryption to support Android Keystore

### DIFF
--- a/src/main/java/com/google/crypto/tink/hybrid/subtle/RsaKemHybridDecrypt.java
+++ b/src/main/java/com/google/crypto/tink/hybrid/subtle/RsaKemHybridDecrypt.java
@@ -63,20 +63,21 @@ public final class RsaKemHybridDecrypt implements HybridDecrypt {
   }
 
   /**
-   * Use alternative factory method is for use with Android KeyStore, whose RSA private key class
-   * does not implement RSAPrivateKey, so we accept `PrivateKey & RSAKey` to support it.
+   * This alternate factory method is to support Android KeyStore, whose RSA private key class
+   * does not implement RSAPrivateKey.
+   *
+   * @param recipientPrivateKey should implement both PrivateKey and RSAKey.
    */
-  public static <KeyT extends PrivateKey & RSAKey> RsaKemHybridDecrypt create(
-          final KeyT recipientPrivateKey,
+  public static RsaKemHybridDecrypt create(
+          final PrivateKey recipientPrivateKey,
           String hkdfHmacAlgo,
           final byte[] hkdfSalt,
           AeadFactory aeadFactory
   ) throws GeneralSecurityException {
-      // Just in case of unchecked casting and type erasure.
-      if (!(recipientPrivateKey instanceof PrivateKey) || !(recipientPrivateKey instanceof RSAKey)) {
+      if (!(recipientPrivateKey instanceof RSAKey)) {
           throw new InvalidKeyException("Must be an RSA private key");
       }
-      return new RsaKemHybridDecrypt((PrivateKey) recipientPrivateKey, hkdfHmacAlgo, hkdfSalt, aeadFactory);
+      return new RsaKemHybridDecrypt(recipientPrivateKey, hkdfHmacAlgo, hkdfSalt, aeadFactory);
   }
 
   @Override


### PR DESCRIPTION
Currently `RsaKemHybridDecrypt` appears it should work perfectly on Android Keystore, except that it turns out Android's implementation of RSA private key does not implement `RSAPrivateKey`, only `PrivateKey` and `RSAKey` separately. So when I try to cast the private key obtained from the keystore to `RSAPrivateKey` before using `RsaKemHybridDecrypt`, I get

> java.lang.ClassCastException: android.security.keystore2.AndroidKeyStoreRSAPrivateKey cannot be cast to java.security.interfaces.RSAPrivateKey

This is presumably because keys in Android keystore are non-extractable, so Android keystore cannot implement `RSAPrivateKey.getPrivateExponent`. See [AndroidKeyStoreRSAPrivateKey](https://android.googlesource.com/platform/frameworks/base/+/marshmallow-mr1-release/keystore/java/android/security/keystore/AndroidKeyStoreRSAPrivateKey.java).

This can be fixed by letting `RsaKemHybridDecrypt` accept a `PrivateKey` instead of `RSAPrivateKey` - slightly less type-safe as it will need to cast to `RSAKey` in a couple places, but not all that out of the ordinary for java.security code.

Fortunately Android keystore's RSA public key implementation does not have this same problem, so nothing needs changing in the corresponding `RsaKemHybridEncrypt`.

Does this change look reasonable?