### PR TITLE
Support building against java 8

### DIFF
--- a/internal/java_8_library.bzl
+++ b/internal/java_8_library.bzl
@@ -1,0 +1,8 @@
+load("@rules_java//java:java_library.bzl", "java_library")
+
+def java_8_library(name, javacopts = [], **kwargs):
+    java_library(
+        name = name,
+        javacopts = javacopts + ["--release", "8"],
+        **kwargs
+    )

--- a/src/main/java/com/google/crypto/tink/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 load("//:template_rule.bzl", "template_rule")
 load("//:tink_version.bzl", "get_tink_version_label")
 

--- a/src/main/java/com/google/crypto/tink/aead/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/aead/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/aead/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/aead/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/java/com/google/crypto/tink/aead/subtle/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/aead/subtle/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/annotations/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/annotations/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/config/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/config/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/config/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/config/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/daead/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/daead/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/daead/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/daead/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/daead/internal/testing/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/daead/internal/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/daead/subtle/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/daead/subtle/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/hybrid/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/hybrid/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/hybrid/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/hybrid/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/java/com/google/crypto/tink/hybrid/internal/testing/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/hybrid/internal/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/hybrid/subtle/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/hybrid/subtle/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/internal/testing/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/internal/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/jwt/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/jwt/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/jwt/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/jwt/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/keyderivation/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/keyderivation/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/keyderivation/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/keyderivation/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/java/com/google/crypto/tink/mac/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/mac/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/mac/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/mac/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/prf/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/prf/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/prf/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/prf/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/signature/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/signature/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 
@@ -1304,6 +1305,7 @@ java_library(
         "//src/main/java/com/google/crypto/tink/signature/internal:ml_dsa_proto_serialization",
         "//src/main/java/com/google/crypto/tink/signature/internal:ml_dsa_verify_conscrypt",
         "//src/main/java/com/google/crypto/tink/util:bytes",
+        "//src/main/java/com/google/crypto/tink/util:maps",
         "//src/main/java/com/google/crypto/tink/util:secret_bytes",
         "@maven//:com_google_code_findbugs_jsr305",
     ],
@@ -1327,6 +1329,7 @@ android_library(
         "//src/main/java/com/google/crypto/tink/signature/internal:ml_dsa_proto_serialization-android",
         "//src/main/java/com/google/crypto/tink/signature/internal:ml_dsa_verify_conscrypt-android",
         "//src/main/java/com/google/crypto/tink/util:bytes-android",
+        "//src/main/java/com/google/crypto/tink/util:maps-android",
         "//src/main/java/com/google/crypto/tink/util:secret_bytes-android",
         "@maven//:com_google_code_findbugs_jsr305",
     ],
@@ -1388,6 +1391,7 @@ android_library(
         "//src/main/java/com/google/crypto/tink/signature/internal:slh_dsa_proto_serialization-android",
         "//src/main/java/com/google/crypto/tink/signature/internal:slh_dsa_verify_conscrypt-android",
         "//src/main/java/com/google/crypto/tink/util:bytes-android",
+        "//src/main/java/com/google/crypto/tink/util:maps-android",
         "//src/main/java/com/google/crypto/tink/util:secret_bytes-android",
         "@maven//:com_google_code_findbugs_jsr305",
     ],
@@ -1449,6 +1453,7 @@ java_library(
         "//src/main/java/com/google/crypto/tink/signature/internal:slh_dsa_proto_serialization",
         "//src/main/java/com/google/crypto/tink/signature/internal:slh_dsa_verify_conscrypt",
         "//src/main/java/com/google/crypto/tink/util:bytes",
+        "//src/main/java/com/google/crypto/tink/util:maps",
         "//src/main/java/com/google/crypto/tink/util:secret_bytes",
         "@maven//:com_google_code_findbugs_jsr305",
     ],
@@ -1489,6 +1494,7 @@ android_library(
         "//src/main/java/com/google/crypto/tink:key-android",
         "//src/main/java/com/google/crypto/tink/internal:output_prefix_util-android",
         "//src/main/java/com/google/crypto/tink/util:bytes-android",
+        "//src/main/java/com/google/crypto/tink/util:maps-android",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_errorprone_error_prone_annotations",
     ],
@@ -1511,6 +1517,7 @@ java_library(
         "//src/main/java/com/google/crypto/tink:key",
         "//src/main/java/com/google/crypto/tink/internal:output_prefix_util",
         "//src/main/java/com/google/crypto/tink/util:bytes",
+        "//src/main/java/com/google/crypto/tink/util:maps",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_errorprone_error_prone_annotations",
     ],

--- a/src/main/java/com/google/crypto/tink/signature/CompositeMlDsaPublicKey.java
+++ b/src/main/java/com/google/crypto/tink/signature/CompositeMlDsaPublicKey.java
@@ -17,12 +17,12 @@
 package com.google.crypto.tink.signature;
 
 import static com.google.crypto.tink.util.Maps.entry;
-import static com.google.crypto.tink.util.Maps.ofEntries;
 
 import com.google.crypto.tink.AccessesPartialKey;
 import com.google.crypto.tink.Key;
 import com.google.crypto.tink.internal.OutputPrefixUtil;
 import com.google.crypto.tink.util.Bytes;
+import com.google.crypto.tink.util.Maps;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 import com.google.errorprone.annotations.RestrictedApi;
@@ -40,7 +40,7 @@ public final class CompositeMlDsaPublicKey extends SignaturePublicKey {
   private static Map<CompositeMlDsaParameters.ClassicalAlgorithm, SignatureParameters>
       createSupportedClassicalParameters() {
     try {
-      return ofEntries(
+      return Maps.ofEntries(
           entry(
               CompositeMlDsaParameters.ClassicalAlgorithm.ED25519,
               Ed25519Parameters.create(Ed25519Parameters.Variant.NO_PREFIX)),

--- a/src/main/java/com/google/crypto/tink/signature/CompositeMlDsaPublicKey.java
+++ b/src/main/java/com/google/crypto/tink/signature/CompositeMlDsaPublicKey.java
@@ -16,6 +16,9 @@
 
 package com.google.crypto.tink.signature;
 
+import static com.google.crypto.tink.util.Maps.entry;
+import static com.google.crypto.tink.util.Maps.ofEntries;
+
 import com.google.crypto.tink.AccessesPartialKey;
 import com.google.crypto.tink.Key;
 import com.google.crypto.tink.internal.OutputPrefixUtil;
@@ -37,58 +40,66 @@ public final class CompositeMlDsaPublicKey extends SignaturePublicKey {
   private static Map<CompositeMlDsaParameters.ClassicalAlgorithm, SignatureParameters>
       createSupportedClassicalParameters() {
     try {
-      return Map.of(
-          CompositeMlDsaParameters.ClassicalAlgorithm.ED25519,
-          Ed25519Parameters.create(Ed25519Parameters.Variant.NO_PREFIX),
-          CompositeMlDsaParameters.ClassicalAlgorithm.ECDSA_P256,
-          EcdsaParameters.builder()
-              .setHashType(EcdsaParameters.HashType.SHA256)
-              .setCurveType(EcdsaParameters.CurveType.NIST_P256)
-              .setVariant(EcdsaParameters.Variant.NO_PREFIX)
-              .setSignatureEncoding(EcdsaParameters.SignatureEncoding.IEEE_P1363)
-              .build(),
-          CompositeMlDsaParameters.ClassicalAlgorithm.ECDSA_P384,
-          EcdsaParameters.builder()
-              .setHashType(EcdsaParameters.HashType.SHA384)
-              .setCurveType(EcdsaParameters.CurveType.NIST_P384)
-              .setSignatureEncoding(EcdsaParameters.SignatureEncoding.IEEE_P1363)
-              .setVariant(EcdsaParameters.Variant.NO_PREFIX)
-              .build(),
-          CompositeMlDsaParameters.ClassicalAlgorithm.ECDSA_P521,
-          EcdsaParameters.builder()
-              .setHashType(EcdsaParameters.HashType.SHA512)
-              .setCurveType(EcdsaParameters.CurveType.NIST_P521)
-              .setSignatureEncoding(EcdsaParameters.SignatureEncoding.IEEE_P1363)
-              .setVariant(EcdsaParameters.Variant.NO_PREFIX)
-              .build(),
-          CompositeMlDsaParameters.ClassicalAlgorithm.RSA3072_PSS,
-          RsaSsaPssParameters.builder()
-              .setModulusSizeBits(3072)
-              .setSigHashType(RsaSsaPssParameters.HashType.SHA256)
-              .setMgf1HashType(RsaSsaPssParameters.HashType.SHA256)
-              .setSaltLengthBytes(32)
-              .setVariant(RsaSsaPssParameters.Variant.NO_PREFIX)
-              .build(),
-          CompositeMlDsaParameters.ClassicalAlgorithm.RSA4096_PSS,
-          RsaSsaPssParameters.builder()
-              .setModulusSizeBits(4096)
-              .setSigHashType(RsaSsaPssParameters.HashType.SHA384)
-              .setMgf1HashType(RsaSsaPssParameters.HashType.SHA384)
-              .setSaltLengthBytes(48)
-              .setVariant(RsaSsaPssParameters.Variant.NO_PREFIX)
-              .build(),
-          CompositeMlDsaParameters.ClassicalAlgorithm.RSA3072_PKCS1,
-          RsaSsaPkcs1Parameters.builder()
-              .setModulusSizeBits(3072)
-              .setHashType(RsaSsaPkcs1Parameters.HashType.SHA256)
-              .setVariant(RsaSsaPkcs1Parameters.Variant.NO_PREFIX)
-              .build(),
-          CompositeMlDsaParameters.ClassicalAlgorithm.RSA4096_PKCS1,
-          RsaSsaPkcs1Parameters.builder()
-              .setModulusSizeBits(4096)
-              .setHashType(RsaSsaPkcs1Parameters.HashType.SHA384)
-              .setVariant(RsaSsaPkcs1Parameters.Variant.NO_PREFIX)
-              .build());
+      return ofEntries(
+          entry(
+              CompositeMlDsaParameters.ClassicalAlgorithm.ED25519,
+              Ed25519Parameters.create(Ed25519Parameters.Variant.NO_PREFIX)),
+          entry(
+              CompositeMlDsaParameters.ClassicalAlgorithm.ECDSA_P256,
+              EcdsaParameters.builder()
+                  .setHashType(EcdsaParameters.HashType.SHA256)
+                  .setCurveType(EcdsaParameters.CurveType.NIST_P256)
+                  .setVariant(EcdsaParameters.Variant.NO_PREFIX)
+                  .setSignatureEncoding(EcdsaParameters.SignatureEncoding.IEEE_P1363)
+                  .build()),
+          entry(
+              CompositeMlDsaParameters.ClassicalAlgorithm.ECDSA_P384,
+              EcdsaParameters.builder()
+                  .setHashType(EcdsaParameters.HashType.SHA384)
+                  .setCurveType(EcdsaParameters.CurveType.NIST_P384)
+                  .setSignatureEncoding(EcdsaParameters.SignatureEncoding.IEEE_P1363)
+                  .setVariant(EcdsaParameters.Variant.NO_PREFIX)
+                  .build()),
+          entry(
+              CompositeMlDsaParameters.ClassicalAlgorithm.ECDSA_P521,
+              EcdsaParameters.builder()
+                  .setHashType(EcdsaParameters.HashType.SHA512)
+                  .setCurveType(EcdsaParameters.CurveType.NIST_P521)
+                  .setSignatureEncoding(EcdsaParameters.SignatureEncoding.IEEE_P1363)
+                  .setVariant(EcdsaParameters.Variant.NO_PREFIX)
+                  .build()),
+          entry(
+              CompositeMlDsaParameters.ClassicalAlgorithm.RSA3072_PSS,
+              RsaSsaPssParameters.builder()
+                  .setModulusSizeBits(3072)
+                  .setSigHashType(RsaSsaPssParameters.HashType.SHA256)
+                  .setMgf1HashType(RsaSsaPssParameters.HashType.SHA256)
+                  .setSaltLengthBytes(32)
+                  .setVariant(RsaSsaPssParameters.Variant.NO_PREFIX)
+                  .build()),
+          entry(
+              CompositeMlDsaParameters.ClassicalAlgorithm.RSA4096_PSS,
+              RsaSsaPssParameters.builder()
+                  .setModulusSizeBits(4096)
+                  .setSigHashType(RsaSsaPssParameters.HashType.SHA384)
+                  .setMgf1HashType(RsaSsaPssParameters.HashType.SHA384)
+                  .setSaltLengthBytes(48)
+                  .setVariant(RsaSsaPssParameters.Variant.NO_PREFIX)
+                  .build()),
+          entry(
+              CompositeMlDsaParameters.ClassicalAlgorithm.RSA3072_PKCS1,
+              RsaSsaPkcs1Parameters.builder()
+                  .setModulusSizeBits(3072)
+                  .setHashType(RsaSsaPkcs1Parameters.HashType.SHA256)
+                  .setVariant(RsaSsaPkcs1Parameters.Variant.NO_PREFIX)
+                  .build()),
+          entry(
+              CompositeMlDsaParameters.ClassicalAlgorithm.RSA4096_PKCS1,
+              RsaSsaPkcs1Parameters.builder()
+                  .setModulusSizeBits(4096)
+                  .setHashType(RsaSsaPkcs1Parameters.HashType.SHA384)
+                  .setVariant(RsaSsaPkcs1Parameters.Variant.NO_PREFIX)
+                  .build()));
     } catch (GeneralSecurityException e) {
       throw new IllegalStateException("Could not create supported classical parameters", e);
     }
@@ -191,7 +202,9 @@ public final class CompositeMlDsaPublicKey extends SignaturePublicKey {
   }
 
   @RestrictedApi(
-      explanation = "Accessing parts of keys can produce unexpected incompatibilities, annotate the function with @AccessesPartialKey",
+      explanation =
+          "Accessing parts of keys can produce unexpected incompatibilities, annotate the function"
+              + " with @AccessesPartialKey",
       link = "https://developers.google.com/tink/design/access_control#accessing_partial_keys",
       allowedOnPath = ".*Test\\.java",
       allowlistAnnotations = {AccessesPartialKey.class})

--- a/src/main/java/com/google/crypto/tink/signature/MlDsaSignKeyManager.java
+++ b/src/main/java/com/google/crypto/tink/signature/MlDsaSignKeyManager.java
@@ -17,7 +17,6 @@
 package com.google.crypto.tink.signature;
 
 import static com.google.crypto.tink.util.Maps.entry;
-import static com.google.crypto.tink.util.Maps.ofEntries;
 
 import com.google.crypto.tink.AccessesPartialKey;
 import com.google.crypto.tink.InsecureSecretKeyAccess;
@@ -32,6 +31,7 @@ import com.google.crypto.tink.signature.MlDsaParameters.MlDsaInstance;
 import com.google.crypto.tink.signature.internal.MlDsaProtoSerialization;
 import com.google.crypto.tink.signature.internal.MlDsaVerifyConscrypt;
 import com.google.crypto.tink.util.Bytes;
+import com.google.crypto.tink.util.Maps;
 import com.google.crypto.tink.util.SecretBytes;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
@@ -110,7 +110,7 @@ public final class MlDsaSignKeyManager {
   }
 
   private static Map<String, Parameters> namedParameters() throws GeneralSecurityException {
-    return ofEntries(
+    return Maps.ofEntries(
         entry(
             "ML_DSA_44",
             MlDsaParameters.create(MlDsaInstance.ML_DSA_44, MlDsaParameters.Variant.TINK)),

--- a/src/main/java/com/google/crypto/tink/signature/MlDsaSignKeyManager.java
+++ b/src/main/java/com/google/crypto/tink/signature/MlDsaSignKeyManager.java
@@ -16,6 +16,9 @@
 
 package com.google.crypto.tink.signature;
 
+import static com.google.crypto.tink.util.Maps.entry;
+import static com.google.crypto.tink.util.Maps.ofEntries;
+
 import com.google.crypto.tink.AccessesPartialKey;
 import com.google.crypto.tink.InsecureSecretKeyAccess;
 import com.google.crypto.tink.Parameters;
@@ -41,8 +44,8 @@ import javax.annotation.Nullable;
 /**
  * This key manager generates new {@code MlDsaPrivateKey} keys and some named parameters.
  *
- * NOTE: in order for the key generation functionality to work, one needs to have a version
- * of Conscrypt installed that supports ML-DSA.
+ * <p>NOTE: in order for the key generation functionality to work, one needs to have a version of
+ * Conscrypt installed that supports ML-DSA.
  */
 public final class MlDsaSignKeyManager {
 
@@ -107,19 +110,25 @@ public final class MlDsaSignKeyManager {
   }
 
   private static Map<String, Parameters> namedParameters() throws GeneralSecurityException {
-    return Map.of(
-        "ML_DSA_44",
-        MlDsaParameters.create(MlDsaInstance.ML_DSA_44, MlDsaParameters.Variant.TINK),
-        "ML_DSA_44_RAW",
-        MlDsaParameters.create(MlDsaInstance.ML_DSA_44, MlDsaParameters.Variant.NO_PREFIX),
-        "ML_DSA_65",
-        MlDsaParameters.create(MlDsaInstance.ML_DSA_65, MlDsaParameters.Variant.TINK),
-        "ML_DSA_65_RAW",
-        MlDsaParameters.create(MlDsaInstance.ML_DSA_65, MlDsaParameters.Variant.NO_PREFIX),
-        "ML_DSA_87",
-        MlDsaParameters.create(MlDsaInstance.ML_DSA_87, MlDsaParameters.Variant.TINK),
-        "ML_DSA_87_RAW",
-        MlDsaParameters.create(MlDsaInstance.ML_DSA_87, MlDsaParameters.Variant.NO_PREFIX));
+    return ofEntries(
+        entry(
+            "ML_DSA_44",
+            MlDsaParameters.create(MlDsaInstance.ML_DSA_44, MlDsaParameters.Variant.TINK)),
+        entry(
+            "ML_DSA_44_RAW",
+            MlDsaParameters.create(MlDsaInstance.ML_DSA_44, MlDsaParameters.Variant.NO_PREFIX)),
+        entry(
+            "ML_DSA_65",
+            MlDsaParameters.create(MlDsaInstance.ML_DSA_65, MlDsaParameters.Variant.TINK)),
+        entry(
+            "ML_DSA_65_RAW",
+            MlDsaParameters.create(MlDsaInstance.ML_DSA_65, MlDsaParameters.Variant.NO_PREFIX)),
+        entry(
+            "ML_DSA_87",
+            MlDsaParameters.create(MlDsaInstance.ML_DSA_87, MlDsaParameters.Variant.TINK)),
+        entry(
+            "ML_DSA_87_RAW",
+            MlDsaParameters.create(MlDsaInstance.ML_DSA_87, MlDsaParameters.Variant.NO_PREFIX)));
   }
 
   /**

--- a/src/main/java/com/google/crypto/tink/signature/SlhDsaSignKeyManager.java
+++ b/src/main/java/com/google/crypto/tink/signature/SlhDsaSignKeyManager.java
@@ -15,6 +15,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.google.crypto.tink.signature;
 
+import static com.google.crypto.tink.util.Maps.entry;
+import static com.google.crypto.tink.util.Maps.ofEntries;
+
 import com.google.crypto.tink.AccessesPartialKey;
 import com.google.crypto.tink.InsecureSecretKeyAccess;
 import com.google.crypto.tink.Parameters;
@@ -94,21 +97,24 @@ public final class SlhDsaSignKeyManager {
    */
   @SuppressWarnings({"CheckedExceptionNotThrown", "JdkImmutableCollections"})
   private static Map<String, Parameters> namedParameters() throws GeneralSecurityException {
-    return Map.of(
-        "SLH_DSA_SHA2_128S_TINK",
-        SlhDsaParameters.createSlhDsaWithSha2And128S(SlhDsaParameters.Variant.TINK),
-        "SLH_DSA_SHA2_128S_RAW",
-        SlhDsaParameters.createSlhDsaWithSha2And128S(SlhDsaParameters.Variant.NO_PREFIX));
+    return ofEntries(
+        entry(
+            "SLH_DSA_SHA2_128S_TINK",
+            SlhDsaParameters.createSlhDsaWithSha2And128S(SlhDsaParameters.Variant.TINK)),
+        entry(
+            "SLH_DSA_SHA2_128S_RAW",
+            SlhDsaParameters.createSlhDsaWithSha2And128S(SlhDsaParameters.Variant.NO_PREFIX)));
   }
 
   /**
    * Registers the {@link SlhDsaProtoSerialization}, named parameters, and the key (pair) creator,
    * for now only supporting SLH-DSA-SHA2-128S in TINK and NO_PREFIX veriants. This enables:
+   *
    * <ul>
-   *   <li> parsing and serializing SLH-DSA keys with {@code TinkProtoKeysetFormat}
-   *   <li> creation of new SLH-DSA keys with {@code KeysetHandle#generateEntryFromParameters}
-   *   <li> creation of new SLH-DSA keys with {@code KeysetHandle#generateEntryFromParametersName}
-   *        (currently "SLH_DSA_SHA2_128S_TINK" and "SLH_DSA_SHA2_128S_RAW" available)
+   *   <li>parsing and serializing SLH-DSA keys with {@code TinkProtoKeysetFormat}
+   *   <li>creation of new SLH-DSA keys with {@code KeysetHandle#generateEntryFromParameters}
+   *   <li>creation of new SLH-DSA keys with {@code KeysetHandle#generateEntryFromParametersName}
+   *       (currently "SLH_DSA_SHA2_128S_TINK" and "SLH_DSA_SHA2_128S_RAW" available)
    * </ul>
    *
    * Currently the key creation functionality will only work if the Conscrypt provider was

--- a/src/main/java/com/google/crypto/tink/signature/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/signature/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/signature/internal/testing/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/signature/internal/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/streamingaead/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/streamingaead/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/streamingaead/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/streamingaead/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/streamingaead/internal/testing/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/streamingaead/internal/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/subtle/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/subtle/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/subtle/prf/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/subtle/prf/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/testing/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/tinkkey/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/tinkkey/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/tinkkey/internal/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/tinkkey/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 

--- a/src/main/java/com/google/crypto/tink/util/BUILD.bazel
+++ b/src/main/java/com/google/crypto/tink/util/BUILD.bazel
@@ -1,8 +1,19 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//:internal/java_8_library.bzl", java_library = "java_8_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "maps",
+    srcs = ["Maps.java"],
+)
+
+android_library(
+    name = "maps-android",
+    srcs = ["Maps.java"],
+)
 
 java_library(
     name = "keys_downloader",

--- a/src/main/java/com/google/crypto/tink/util/Maps.java
+++ b/src/main/java/com/google/crypto/tink/util/Maps.java
@@ -1,0 +1,19 @@
+package com.google.crypto.tink.util;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class Maps {
+  @SafeVarargs
+  public static <K, V> Map<K, V> ofEntries(Map.Entry<K, V>... entries) {
+    return Arrays.stream(entries).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  public static <K, V> Map.Entry<K, V> entry(K k, V v) {
+    return new AbstractMap.SimpleImmutableEntry<>(k, v);
+  }
+
+  private Maps() {}
+}

--- a/src/main/java/com/google/crypto/tink/util/Maps.java
+++ b/src/main/java/com/google/crypto/tink/util/Maps.java
@@ -1,14 +1,20 @@
 package com.google.crypto.tink.util;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toMap;
+
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public final class Maps {
   @SafeVarargs
   public static <K, V> Map<K, V> ofEntries(Map.Entry<K, V>... entries) {
-    return Arrays.stream(entries).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return Arrays.stream(entries)
+        .collect(
+            collectingAndThen(
+                toMap(Map.Entry::getKey, Map.Entry::getValue), Collections::unmodifiableMap));
   }
 
   public static <K, V> Map.Entry<K, V> entry(K k, V v) {


### PR DESCRIPTION
By adding `--release 8` to our java compiler options, we can ask newer versions of Java to target 8 apis. This would avoid needing to make changes like https://github.com/tink-crypto/tink-java/commit/e357c85680f7cf63c122ad3c98ff04873929a7c2 manually.

Fixes https://github.com/tink-crypto/tink-java/issues/68 (if compatibility with 8 is still desired)