### PR TITLE
Report malformed JSON keyset fields as IOException instead of an uncaught exception

### DIFF
--- a/src/main/java/com/google/crypto/tink/JsonKeysetReader.java
+++ b/src/main/java/com/google/crypto/tink/JsonKeysetReader.java
@@ -163,7 +163,7 @@ public final class JsonKeysetReader implements KeysetReader {
     try {
       return keysetFromJson(
           JsonParser.parse(new String(Util.readAll(inputStream), UTF_8)).getAsJsonObject());
-    } catch (JsonParseException | IllegalStateException e) {
+    } catch (JsonParseException | IllegalStateException | UnsupportedOperationException e) {
       throw new IOException(e);
     } finally {
       if (inputStream != null) {
@@ -177,7 +177,7 @@ public final class JsonKeysetReader implements KeysetReader {
     try {
       return encryptedKeysetFromJson(
           JsonParser.parse(new String(Util.readAll(inputStream), UTF_8)).getAsJsonObject());
-    } catch (JsonParseException | IllegalStateException e) {
+    } catch (JsonParseException | IllegalStateException | UnsupportedOperationException e) {
       throw new IOException(e);
     } finally {
       if (inputStream != null) {

--- a/src/test/java/com/google/crypto/tink/JsonKeysetReaderTest.java
+++ b/src/test/java/com/google/crypto/tink/JsonKeysetReaderTest.java
@@ -469,6 +469,25 @@ public class JsonKeysetReaderTest {
   }
 
   @Test
+  public void readKeyset_nonPrimitiveStatusField_throwsIOException() throws Exception {
+    // "status" is a JSON object, so gson's getAsString() raises UnsupportedOperationException while
+    // parsing the key. read() must surface that as an IOException rather than let it escape
+    // uncaught to the caller.
+    String jsonKeysetString =
+        "{\"key\":[{\"keyData\":{},\"status\":{},\"keyId\":1,\"outputPrefixType\":\"TINK\"}]}";
+    assertThrows(IOException.class, () -> JsonKeysetReader.withString(jsonKeysetString).read());
+  }
+
+  @Test
+  public void readEncrypted_nonPrimitiveEncryptedKeysetField_throwsIOException() throws Exception {
+    // "encryptedKeyset" is a JSON object, so getAsString() raises UnsupportedOperationException.
+    // readEncrypted() must surface that as an IOException rather than let it escape uncaught.
+    String jsonEncryptedKeyset = "{\"encryptedKeyset\":{}}";
+    assertThrows(
+        IOException.class, () -> JsonKeysetReader.withString(jsonEncryptedKeyset).readEncrypted());
+  }
+
+  @Test
   public void testReadKeyset_withDuplicatedMapKey_throws() throws Exception {
     String jsonKeysetString = "{"
         + "\"primaryKeyId\": 123,"


### PR DESCRIPTION
## Problem

`JsonKeysetReader.read()` and `readEncrypted()` declare `throws IOException`, and the public `TinkJsonProtoKeysetFormat.parseKeyset*` helpers wrap that into `throws GeneralSecurityException`. Their `try` blocks catch `JsonParseException | IllegalStateException` and rethrow as `IOException`.

However, when a JSON keyset sets a **string-typed field** — e.g. `status`, `typeUrl`, `keyMaterialType`, `value`, `encryptedKeyset` — to a JSON **object** or **array**, gson's `JsonElement.getAsString()` throws `UnsupportedOperationException`. That is a `RuntimeException` and is **not** covered by the existing catch, so it propagates uncaught, past the documented `IOException` / `GeneralSecurityException` contract.

A caller that parses an untrusted keyset (for example a public keyset via `parseKeysetWithoutSecret`) and handles only the declared exceptions will therefore see an unexpected `UnsupportedOperationException` instead of a clean parse error.

Minimal reproducer (the field is a `{}` instead of a string):

```json
{"primaryKeyId":1,"key":[{"keyData":{"typeUrl":{},"value":"","keyMaterialType":"SYMMETRIC"},"status":"ENABLED","keyId":1,"outputPrefixType":"TINK"}]}
```

`getAsString()` on the object-valued `typeUrl` throws `UnsupportedOperationException`. (The existing `testRead_outputPrefixTypeIsNotAString` test uses a *number*, which gson coerces to a string, so the object/array case is not currently exercised.)

## Fix

Add `UnsupportedOperationException` to the catch clauses in `read()` and `readEncrypted()` so malformed input is reported as `IOException`, consistent with the other parse errors.

```java
} catch (JsonParseException | IllegalStateException | UnsupportedOperationException e) {
  throw new IOException(e);
}
```

Happy to add a test covering object/array-valued string fields if preferred.
