### PR TITLE
Use constant-time comparison for output prefix verification in MAC

### DIFF
--- a/src/main/java/com/google/crypto/tink/mac/internal/ChunkedAesCmacImpl.java
+++ b/src/main/java/com/google/crypto/tink/mac/internal/ChunkedAesCmacImpl.java
@@ -22,10 +22,11 @@ import com.google.crypto.tink.mac.AesCmacKey;
 import com.google.crypto.tink.mac.ChunkedMac;
 import com.google.crypto.tink.mac.ChunkedMacComputation;
 import com.google.crypto.tink.mac.ChunkedMacVerification;
-import com.google.crypto.tink.util.Bytes;
 import com.google.errorprone.annotations.Immutable;
 import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.security.Provider;
+import java.util.Arrays;
 
 /** AES-CMAC implementation of the ChunkedMac interface. */
 @Immutable
@@ -52,7 +53,9 @@ public final class ChunkedAesCmacImpl implements ChunkedMac {
     if (tag.length < key.getOutputPrefix().size()) {
       throw new GeneralSecurityException("Tag too short");
     }
-    if (!key.getOutputPrefix().equals(Bytes.copyFrom(tag, 0, key.getOutputPrefix().size()))) {
+    if (!MessageDigest.isEqual(
+        key.getOutputPrefix().toByteArray(),
+        Arrays.copyOf(tag, key.getOutputPrefix().size()))) {
       throw new GeneralSecurityException("Wrong tag prefix");
     }
     return ChunkedMacVerificationFromComputation.create(new ChunkedAesCmacComputation(key), tag);

--- a/src/main/java/com/google/crypto/tink/mac/internal/ChunkedHmacImpl.java
+++ b/src/main/java/com/google/crypto/tink/mac/internal/ChunkedHmacImpl.java
@@ -21,9 +21,10 @@ import com.google.crypto.tink.mac.ChunkedMac;
 import com.google.crypto.tink.mac.ChunkedMacComputation;
 import com.google.crypto.tink.mac.ChunkedMacVerification;
 import com.google.crypto.tink.mac.HmacKey;
-import com.google.crypto.tink.util.Bytes;
 import com.google.errorprone.annotations.Immutable;
 import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.util.Arrays;
 
 /** Class that provides the functionality expressed by the ChunkedMac interface with HMAC. */
 @Immutable
@@ -53,7 +54,9 @@ public final class ChunkedHmacImpl implements ChunkedMac {
     if (tag.length < key.getOutputPrefix().size()) {
       throw new GeneralSecurityException("Tag too short");
     }
-    if (!key.getOutputPrefix().equals(Bytes.copyFrom(tag, 0, key.getOutputPrefix().size()))) {
+    if (!MessageDigest.isEqual(
+        key.getOutputPrefix().toByteArray(),
+        Arrays.copyOf(tag, key.getOutputPrefix().size()))) {
       throw new GeneralSecurityException("Wrong tag prefix");
     }
     return ChunkedMacVerificationFromComputation.create(new ChunkedHmacComputation(key), tag);

--- a/src/main/java/com/google/crypto/tink/mac/internal/LegacyFullMac.java
+++ b/src/main/java/com/google/crypto/tink/mac/internal/LegacyFullMac.java
@@ -28,6 +28,7 @@ import com.google.crypto.tink.internal.ProtoConversions;
 import com.google.crypto.tink.proto.OutputPrefixType;
 import com.google.crypto.tink.subtle.Bytes;
 import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.util.Arrays;
 
 /**
@@ -97,7 +98,7 @@ public final class LegacyFullMac implements Mac {
       macNoPrefix = Arrays.copyOfRange(mac, CryptoFormat.NON_RAW_PREFIX_SIZE, mac.length);
     }
 
-    if (!Arrays.equals(identifier, prefix)) {
+    if (!MessageDigest.isEqual(identifier, prefix)) {
       throw new GeneralSecurityException("wrong prefix");
     }
 


### PR DESCRIPTION
## Summary

Three places in MAC verification use non-constant-time comparisons for the output prefix check, inconsistent with the fix recently applied in `ChunkedMacVerificationFromComputation` (175df91c).

- `ChunkedHmacImpl.createVerification()` — `util.Bytes.equals()` → `Arrays.equals()` (non-CT)
- `ChunkedAesCmacImpl.createVerification()` — same
- `LegacyFullMac.verifyMac()` — `Arrays.equals()` directly (non-CT)

All three are replaced with `MessageDigest.isEqual()` which is guaranteed constant-time by the JCA spec, consistent with the pattern already used in `ChunkedMacVerificationFromComputation`.

## Files Changed

| File | Change |
|---|---|
| `ChunkedHmacImpl.java` | `Bytes.equals()` → `MessageDigest.isEqual()` |
| `ChunkedAesCmacImpl.java` | `Bytes.equals()` → `MessageDigest.isEqual()` |
| `LegacyFullMac.java` | `Arrays.equals()` → `MessageDigest.isEqual()` |

Fixes #72.