### PR TITLE
Fix: HpkePrimitiveFactory throws IllegalArgumentException instead of GeneralSecurityException for invalid IDs

### DIFF
--- a/src/main/java/com/google/crypto/tink/hybrid/internal/HpkePrimitiveFactory.java
+++ b/src/main/java/com/google/crypto/tink/hybrid/internal/HpkePrimitiveFactory.java
@@ -37,7 +37,7 @@ public final class HpkePrimitiveFactory {
     } else if (Arrays.equals(kemId, HpkeUtil.P521_HKDF_SHA512_KEM_ID)) {
       return NistCurvesHpkeKem.fromCurve(EllipticCurves.CurveType.NIST_P521);
     }
-    throw new IllegalArgumentException("Unrecognized HPKE KEM identifier");
+    throw new GeneralSecurityException("Unrecognized HPKE KEM identifier");
   }
 
   /** Returns an {@link HpkeKem} primitive corresponding to {@code kemId}. */
@@ -51,11 +51,11 @@ public final class HpkePrimitiveFactory {
     } else if (kemId == HpkeParameters.KemId.DHKEM_P521_HKDF_SHA512) {
       return NistCurvesHpkeKem.fromCurve(EllipticCurves.CurveType.NIST_P521);
     }
-    throw new IllegalArgumentException("Unrecognized HPKE KEM identifier");
+    throw new GeneralSecurityException("Unrecognized HPKE KEM identifier");
   }
 
   /** Returns an {@link HpkeKdf} primitive corresponding to {@code kdfId}. */
-  public static HpkeKdf createKdf(byte[] kdfId) {
+  public static HpkeKdf createKdf(byte[] kdfId) throws GeneralSecurityException {
     if (Arrays.equals(kdfId, HpkeUtil.HKDF_SHA256_KDF_ID)) {
       return new HkdfHpkeKdf("HmacSha256");
     } else if (Arrays.equals(kdfId, HpkeUtil.HKDF_SHA384_KDF_ID)) {
@@ -63,11 +63,11 @@ public final class HpkePrimitiveFactory {
     } else if (Arrays.equals(kdfId, HpkeUtil.HKDF_SHA512_KDF_ID)) {
       return new HkdfHpkeKdf("HmacSha512");
     }
-    throw new IllegalArgumentException("Unrecognized HPKE KDF identifier");
+    throw new GeneralSecurityException("Unrecognized HPKE KDF identifier");
   }
 
   /** Returns an {@link HpkeKdf} primitive corresponding to {@code kdfId}. */
-  public static HpkeKdf createKdf(HpkeParameters.KdfId kdfId) {
+  public static HpkeKdf createKdf(HpkeParameters.KdfId kdfId) throws GeneralSecurityException {
     if (kdfId == HpkeParameters.KdfId.HKDF_SHA256) {
       return new HkdfHpkeKdf("HmacSha256");
     } else if (kdfId == HpkeParameters.KdfId.HKDF_SHA384) {
@@ -75,7 +75,7 @@ public final class HpkePrimitiveFactory {
     } else if (kdfId == HpkeParameters.KdfId.HKDF_SHA512) {
       return new HkdfHpkeKdf("HmacSha512");
     }
-    throw new IllegalArgumentException("Unrecognized HPKE KDF identifier");
+    throw new GeneralSecurityException("Unrecognized HPKE KDF identifier");
   }
 
   /** Returns an {@link HpkeAead} primitive corresponding to {@code aeadId}. */
@@ -87,7 +87,7 @@ public final class HpkePrimitiveFactory {
     } else if (Arrays.equals(aeadId, HpkeUtil.CHACHA20_POLY1305_AEAD_ID)) {
       return new ChaCha20Poly1305HpkeAead();
     }
-    throw new IllegalArgumentException("Unrecognized HPKE AEAD identifier");
+    throw new GeneralSecurityException("Unrecognized HPKE AEAD identifier");
   }
 
   /** Returns an {@link HpkeAead} primitive corresponding to {@code aeadId}. */
@@ -99,7 +99,7 @@ public final class HpkePrimitiveFactory {
     } else if (aeadId == HpkeParameters.AeadId.CHACHA20_POLY1305) {
       return new ChaCha20Poly1305HpkeAead();
     }
-    throw new IllegalArgumentException("Unrecognized HPKE AEAD identifier");
+    throw new GeneralSecurityException("Unrecognized HPKE AEAD identifier");
   }
 
   private HpkePrimitiveFactory() {}

--- a/src/test/java/com/google/crypto/tink/hybrid/internal/HpkePrimitiveFactoryTest.java
+++ b/src/test/java/com/google/crypto/tink/hybrid/internal/HpkePrimitiveFactoryTest.java
@@ -18,6 +18,8 @@ package com.google.crypto.tink.hybrid.internal;
 
 import static org.junit.Assert.assertThrows;
 
+import java.security.GeneralSecurityException;
+
 import com.google.common.truth.Expect;
 import com.google.crypto.tink.hybrid.HpkeParameters;
 import org.junit.Rule;
@@ -147,7 +149,7 @@ public final class HpkePrimitiveFactoryTest {
     byte[] invalidKemId = new byte[] {0, 0};
 
     assertThrows(
-        IllegalArgumentException.class, () -> HpkePrimitiveFactory.createKem(invalidKemId));
+        GeneralSecurityException.class, () -> HpkePrimitiveFactory.createKem(invalidKemId));
   }
 
   @Theory
@@ -173,7 +175,7 @@ public final class HpkePrimitiveFactoryTest {
     byte[] invalidKdfId = new byte[] {0, 0};
 
     assertThrows(
-        IllegalArgumentException.class, () -> HpkePrimitiveFactory.createKdf(invalidKdfId));
+        GeneralSecurityException.class, () -> HpkePrimitiveFactory.createKdf(invalidKdfId));
   }
 
   @Theory
@@ -201,7 +203,7 @@ public final class HpkePrimitiveFactoryTest {
     byte[] invalidAeadId = new byte[] {0, 0};
 
     assertThrows(
-        IllegalArgumentException.class, () -> HpkePrimitiveFactory.createAead(invalidAeadId));
+        GeneralSecurityException.class, () -> HpkePrimitiveFactory.createAead(invalidAeadId));
   }
 
   @Theory


### PR DESCRIPTION
## Problem

`HpkePrimitiveFactory.createKem()`, `createKdf()`, and `createAead()` throw
`IllegalArgumentException` when an unrecognized algorithm identifier is passed.
This is inconsistent with the rest of Tink's internal API, which uses
`GeneralSecurityException` as the standard exception type for cryptographic failures.

Callers that wrap these methods inside `catch (GeneralSecurityException e)` —
the idiomatic Tink pattern — will not catch the failure. The exception propagates
as an unchecked `RuntimeException`, bypassing any recovery logic.

Additionally, `createKdf(byte[])` and `createKdf(KdfId)` did not declare
`throws GeneralSecurityException`, making the inconsistency visible in the signature.

## Evidence

- `HpkePrimitiveFactory.createKem(byte[])` → `throw new IllegalArgumentException(...)`
- `HpkePrimitiveFactory.createKem(KemId)` → `throw new IllegalArgumentException(...)`
- `HpkePrimitiveFactory.createKdf(byte[])` → `throw new IllegalArgumentException(...)`
- `HpkePrimitiveFactory.createKdf(KdfId)` → `throw new IllegalArgumentException(...)`

Factory methods in Tink must throw `GeneralSecurityException` for invalid parameters — not unchecked exceptions.

## Changes

**`HpkePrimitiveFactory.java`:**
- Changed all 6 `throw new IllegalArgumentException(...)` to `GeneralSecurityException`
- Added `throws GeneralSecurityException` to both `createKdf` overloads

**`HpkePrimitiveFactoryTest.java`:**
- Updated 3 error-path tests to expect `GeneralSecurityException`
- Added `import java.security.GeneralSecurityException`

## Impact

Source-compatible for callers already catching `GeneralSecurityException`.
The `createKdf()` signature change adds a checked exception where none existed before.